### PR TITLE
Miscellaneous bash fixes

### DIFF
--- a/ec2-snap-db
+++ b/ec2-snap-db
@@ -65,6 +65,9 @@ check_aws_key() {
 check_aws_key AWS_ACCESS_KEY_ID AWS_ACCESS_KEY
 check_aws_key AWS_SECRET_ACCESS_KEY AWS_SECRET_KEY
 
+export AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
+export AWS_ACCESS_KEY AWS_SECRET_KEY
+
 SNAP_DB_MOUNTS+=("$@")
 if [ ${#SNAP_DB_MOUNTS[@]} -eq 0 ]; then
   echo "Error: no mounts to snapshot" 2>&1

--- a/ec2-snap-db
+++ b/ec2-snap-db
@@ -54,7 +54,7 @@ check_aws_key() {
   if [ -n "$FOUND_KEY" ]; then
     for KEY in "$@"; do
       if [ -z "${!KEY}" ]; then
-        declare -g -x "$KEY=$FOUND_VALUE"
+        readonly "$KEY=$FOUND_VALUE"
       fi
     done
   else

--- a/ec2-volumes-for-mount
+++ b/ec2-volumes-for-mount
@@ -37,6 +37,9 @@ check_aws_key() {
 check_aws_key AWS_ACCESS_KEY_ID AWS_ACCESS_KEY
 check_aws_key AWS_SECRET_ACCESS_KEY AWS_SECRET_KEY
 
+export AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
+export AWS_ACCESS_KEY AWS_SECRET_KEY
+
 real_device() {
   local DEVICE="$1"
   test -L $DEVICE && DEVICE=`readlink -f $DEVICE`

--- a/ec2-volumes-for-mount
+++ b/ec2-volumes-for-mount
@@ -26,7 +26,7 @@ check_aws_key() {
   if [ -n "$FOUND_KEY" ]; then
     for KEY in "$@"; do
       if [ -z "${!KEY}" ]; then
-        declare -g -x "$KEY=$FOUND_VALUE"
+        readonly "$KEY=$FOUND_VALUE"
       fi
     done
   else


### PR DESCRIPTION
Miscellaneous fixes based on feedback from the App Force team.
- Changes `declare -g -x` to `readonly` to work with older Bash versions
- Ensure AWS keys are exported before calling child processes

I believe this fixes #1 

cc/ @balugeorge @bkconrad 
